### PR TITLE
Specify babel target

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,12 @@
 {
   "presets": [
-    ["@babel/preset-env"]
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "6.0"
+        }
+      }
+    ]
   ],
-  "plugins": [
-    "@babel/plugin-transform-runtime"
-  ]
 }


### PR DESCRIPTION
To avoid transpilation runtime error.

Closes #1.