### PR TITLE
Fix race condition when building with fresh cache

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -54,7 +54,7 @@ exports.sourceNodes = async ({ actions, store, cache, createNodeId }, { username
 
   // Process data into nodes.
   if (data) {
-    data.forEach(async datum => {
+    for (const datum of data) {
       const res = await normalize.downloadMediaFile({
         datum: processDatum(datum),
         store,
@@ -64,6 +64,6 @@ exports.sourceNodes = async ({ actions, store, cache, createNodeId }, { username
         touchNode
       })
       createNode(res)
-    })
+    }
   }
 }


### PR DESCRIPTION
There's a race condition when building with no cache, which is easily verifiable by building on Netlify or removing /.cache. Building again after the failure (this time with cache) works, but is not a solution for CI.

This PR fixes it by waiting until each image is sequentially downloaded, to avoid messing up the ordering.

```
4:21:46 PM: Executing user command: gatsby build
4:21:47 PM: success open and validate gatsby-config — 0.011 s
4:21:48 PM: success load plugins — 0.306 s
4:21:48 PM: success onPreInit — 0.625 s
4:21:48 PM: success delete html and css files from previous builds — 0.005 s
4:21:48 PM: success initialize cache — 0.006 s
4:21:48 PM: success copy gatsby files — 0.013 s
4:21:48 PM: success onPreBootstrap — 0.003 s
4:21:49 PM: warning The gatsby-source-instagram plugin has generated no Gatsby nodes. Do you need it?
4:21:49 PM: success source and transform nodes — 0.730 s
4:21:49 PM: success building schema — 0.259 s
4:21:49 PM: success createPages — 0.000 s
4:21:49 PM: success createPagesStatefully — 0.111 s
4:21:49 PM: success onPreExtractQueries — 0.004 s
4:21:50 PM: success update schema — 0.144 s
4:21:50 PM: error GraphQL Error Unknown field `allInstaNode` on type `Query`
4:21:50 PM:   file: /opt/build/repo/src/components/home/Instagram/index.js
4:21:50 PM:    1 |
4:21:50 PM:    2 |       query {
4:21:50 PM: >  3 |         allInstaNode {
4:21:50 PM:      |         ^
4:21:50 PM:    4 |           edges {
4:21:50 PM:    5 |             node {
4:21:50 PM:    6 |               id
4:21:50 PM:    7 |               likes {
4:21:50 PM:    8 |                 count
4:21:50 PM:    9 |               }
4:21:50 PM:   10 |               localFile {
4:21:50 PM:   11 |                 childImageSharp {
4:21:50 PM:   12 |                   fluid(maxHeight: 400, maxWidth: 400, quality: 90) {
4:21:50 PM:   13 |                     ...GatsbyImageSharpFluid_withWebp
4:21:50 PM: Caching artifacts
4:21:50 PM: Started saving node modules
4:21:50 PM: Finished saving node modules
4:21:50 PM: Started saving yarn cache
4:21:50 PM: Finished saving yarn cache
4:21:50 PM: Started saving pip cache
4:21:50 PM: Finished saving pip cache
4:21:50 PM: Started saving emacs cask dependencies
4:21:50 PM: Finished saving emacs cask dependencies
4:21:50 PM: Started saving maven dependencies
4:21:50 PM: Finished saving maven dependencies
4:21:50 PM: Started saving boot dependencies
4:21:50 PM: Finished saving boot dependencies
4:21:50 PM: Started saving go dependencies
4:21:50 PM: Finished saving go dependencies
4:21:50 PM: Error running command: Build script returned non-zero exit code: 1
4:21:50 PM: Failing build: Failed to build site
4:21:50 PM: failed during stage 'building site': Build script returned non-zero exit code: 1
4:21:50 PM: Finished processing build request in 1m3.155791849s
```


