### PR TITLE
 fix: improve regexes, ensure ; removal

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,7 +8,10 @@ async function getInstagramPosts(username) {
     .then((response) => {
     // handle success
       const $ = cheerio.load(response.data)
-      const jsonData = $(`html > body > script`).get(0).children[0].data.replace(`window._sharedData =`, ``).replace(`;`, ``)
+      const jsonData = $(`html > body > script`)
+        .get(0).children[0].data
+        .replace(/window\._sharedData\s?=\s?{/, `{`)
+        .replace(/;$/g, ``)
       const json = JSON.parse(jsonData).entry_data.ProfilePage[0].graphql
       const photos = []
       json.user.edge_owner_to_timeline_media.edges.forEach((edge) => {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -16,7 +16,6 @@ exports.downloadMediaFile = async ({
     // If we have cached media data reuse
     // previously created file node to not try to redownload
     if (cacheMediaData) {
-      console.log("using caaaache")
       fileNodeID = cacheMediaData.fileNodeID
       touchNode({ nodeId: cacheMediaData.fileNodeID })
     }


### PR DESCRIPTION
the first regex now removes the whitespace after `=` as well, just to make sure, and both whitespaces are optional
the second regex would only work if no `;` semicolon was contained anywhere else in the content, e.g. in the image caption
the fix makes sure only the last `;` will be removed

remove `console.log("using caaaache")`