### PR TITLE
add preview and mediaType to fields & use preview url to create localFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ query {
         id
         likes
         comments
+        mediaType
+        preview
         original
         timestamp
         caption

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -71,7 +71,7 @@ function processDatum(datum) {
       _.get(datum, "edge_media_to_caption.edges[0].node.text") || datum.caption,
     thumbnails: datum.thumbnail_resources,
     mediaType: datum.__typename || datum.media_type,
-    preview: datum.display_url || datum.thumbnail_url,
+    preview: datum.display_url || datum.thumbnail_url || datum.media_url,
     original: datum.display_url || datum.media_url,
     timestamp:
       datum.taken_at_timestamp || new Date(datum.timestamp).getTime() / 1000,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -4,40 +4,38 @@ const cheerio = require(`cheerio`)
 const crypto = require(`crypto`)
 const normalize = require(`./normalize`)
 
-async function getPublicInstagramPosts({
-  username
-}) {
-  return axios.get(`https://www.instagram.com/${username}/`)
-    .then((response) => {
+async function getPublicInstagramPosts({ username }) {
+  return axios
+    .get(`https://www.instagram.com/${username}/`)
+    .then(response => {
       // handle success
       const $ = cheerio.load(response.data)
       const jsonData = $(`html > body > script`)
-        .get(0).children[0].data
-        .replace(/window\._sharedData\s?=\s?{/, `{`)
+        .get(0)
+        .children[0].data.replace(/window\._sharedData\s?=\s?{/, `{`)
         .replace(/;$/g, ``)
       const json = JSON.parse(jsonData).entry_data.ProfilePage[0].graphql
       const photos = []
-      json.user.edge_owner_to_timeline_media.edges.forEach((edge) => {
+      json.user.edge_owner_to_timeline_media.edges.forEach(edge => {
         if (edge.node) {
           photos.push(edge.node)
         }
       })
       return photos
     })
-    .catch((err) => {
+    .catch(err => {
       console.warn(`\nCould not fetch instagram posts. Error status ${err}`)
       return null
     })
 }
 
-async function getInstagramPosts({
-  access_token,
-  instagram_id,
-  username
-}) {
-  return axios.get(`https://graph.facebook.com/v3.1/${instagram_id}/media?fields=media_url,caption,media_type,like_count,shortcode,timestamp,comments_count&limit=100&access_token=${access_token}`)
-    .then(async (response) => {
-      let results = [];
+async function getInstagramPosts({ access_token, instagram_id, username }) {
+  return axios
+    .get(
+      `https://graph.facebook.com/v3.1/${instagram_id}/media?fields=media_url,thumbnail_url,caption,media_type,like_count,shortcode,timestamp,comments_count&limit=100&access_token=${access_token}`
+    )
+    .then(async response => {
+      let results = []
       results.push(...response.data.data)
       while (response.data.paging.next) {
         response = await axios(response.data.paging.next)
@@ -45,12 +43,14 @@ async function getInstagramPosts({
       }
       return results
     })
-    .catch(async (err) => {
-      console.warn(`\nCould not get instagram posts using the Graph API. Error status ${err}`)
+    .catch(async err => {
+      console.warn(
+        `\nCould not get instagram posts using the Graph API. Error status ${err}`
+      )
       console.warn(`Falling back to public api... with ${username}`)
       if (username) {
         const photos = await getPublicInstagramPosts({
-          username
+          username,
         })
         return photos
       }
@@ -63,16 +63,21 @@ function processDatum(datum) {
     id: datum.shortcode,
     parent: `__SOURCE__`,
     internal: {
-      type: `InstaNode`
+      type: `InstaNode`,
     },
     children: [],
-    likes: _.get(datum, 'edge_liked_by.count') || datum.like_count,
-    caption: _.get(datum, 'edge_media_to_caption.edges[0].node.text') || datum.caption,
+    likes: _.get(datum, "edge_liked_by.count") || datum.like_count,
+    caption:
+      _.get(datum, "edge_media_to_caption.edges[0].node.text") || datum.caption,
     thumbnails: datum.thumbnail_resources,
+    mediaType: datum.__typename || datum.media_type,
+    preview: datum.display_url || datum.thumbnail_url,
     original: datum.display_url || datum.media_url,
-    timestamp: datum.taken_at_timestamp || new Date(datum.timestamp).getTime() / 1000,
+    timestamp:
+      datum.taken_at_timestamp || new Date(datum.timestamp).getTime() / 1000,
     dimensions: datum.dimensions,
-    comments: _.get(datum, 'edge_media_to_comment.count') || datum.comments_count,
+    comments:
+      _.get(datum, "edge_media_to_comment.count") || datum.comments_count,
   }
 
   // Get content digest of node. (Required field)
@@ -85,18 +90,13 @@ function processDatum(datum) {
   return node
 }
 
-exports.sourceNodes = async ({
-  actions,
-  store,
-  cache,
-  createNodeId
-}, options) => {
-  const {
-    createNode,
-    touchNode
-  } = actions
+exports.sourceNodes = async (
+  { actions, store, cache, createNodeId },
+  options
+) => {
+  const { createNode, touchNode } = actions
 
-  let data;
+  let data
   if (options.access_token && options.instagram_id) {
     data = await getInstagramPosts(options)
   } else {
@@ -113,7 +113,7 @@ exports.sourceNodes = async ({
           cache,
           createNode,
           createNodeId,
-          touchNode
+          touchNode,
         })
         createNode(res)
       })

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -1,6 +1,4 @@
-const {
-  createRemoteFileNode
-} = require(`gatsby-source-filesystem`)
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
 exports.downloadMediaFile = async ({
   datum,
@@ -20,7 +18,7 @@ exports.downloadMediaFile = async ({
     if (cacheMediaData) {
       fileNodeID = cacheMediaData.fileNodeID
       touchNode({
-        nodeId: cacheMediaData.fileNodeID
+        nodeId: cacheMediaData.fileNodeID,
       })
     }
 
@@ -28,7 +26,7 @@ exports.downloadMediaFile = async ({
     if (!fileNodeID) {
       try {
         const fileNode = await createRemoteFileNode({
-          url: datum.original,
+          url: datum.preview,
           store,
           cache,
           createNode,
@@ -52,4 +50,4 @@ exports.downloadMediaFile = async ({
     datum.localFile___NODE = fileNodeID
   }
   return datum
-};
+}


### PR DESCRIPTION
using added preview field to create localFile. fixes query breaking when the mediatype is "VIDEO" because there's no childImageSharp node created for video files