### PR TITLE
Create node for fetching a user's profile informations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,7 @@
         "requireReturnForObjectLiteral": true
       }
     ],
-    "consistent-return": ["error"],
+    "consistent-return": "off",
     "no-console": "off",
     "no-inner-declarations": "off",
     "prettier/prettier": "error",

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ plugins: [
 ```
 
 ### Public scraping for a user's profile
+
 If you want to source a user's profile from his username then you need the following:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -9,20 +9,24 @@
 
 </div>
 
-Source plugin for sourcing data from Instagram. There are three ways to get information from instagram:
+Source plugin for sourcing data from Instagram. There are four ways to get information from instagram:
 
-- scraping the homepage of the Instagram account. It can only get last 12 photos.
+- scraping the posts of an Instagram account. It can only get last 12 photos.
 - scraping a hashtag page.
+- scraping a user profile's informations.
 - querying the Instagram Graph Api using a provided `access_token`
 
 # Table of Contents
 
 - [Install](#install)
 - [How to use](#how-to-use)
-  - [Public scraping](#public-scraping)
+  - [Public scraping for posts](#public-scraping-for-posts)
+  - [Public scraping for a user's profile](#public-scraping-for-a-users-profile)
   - [Graph API](#graph-api)
-  - [Hashtag scraping](#graph-api)
+  - [Hashtag scraping](#hashtag-scraping)
 - [How to query](#how-to-query)
+  - [Posts](#posts)
+  - [User profile information](#user-profile-information)
 - [Image processing](#image-processing)
 - [Instagram Graph API token](#instagram-graph-api-token)
 
@@ -32,7 +36,7 @@ Source plugin for sourcing data from Instagram. There are three ways to get info
 
 ## How to use
 
-### Public scraping
+### Public scraping for posts
 
 If you intend to use the public scraping method then you need to pass the concerning username
 
@@ -42,6 +46,22 @@ plugins: [
   {
     resolve: `gatsby-source-instagram`,
     options: {
+      username: `username`,
+    },
+  },
+]
+```
+
+### Public scraping for a user's profile
+If you want to source a user's profile from his username then you need the following:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-source-instagram`,
+    options: {
+      type: `user-profile`,
       username: `username`,
     },
   },
@@ -86,6 +106,8 @@ plugins: [
 ```
 
 ## How to query
+
+### Posts
 
 The plugin tries to provide uniform results regardless of the way you choose to retrieve the information
 
@@ -138,6 +160,34 @@ query {
         }
       }
     }
+  }
+}
+```
+
+### User profile information
+
+Fields include:
+
+- id
+- username
+- full_name
+- biography
+- edge_followed_by (followers)
+- edge_follow (who the user follows)
+- profile_pic_url
+- profile_pic_url_hd
+
+```graphql
+query {
+  instaUserNode {
+    id
+    username
+    full_name
+    biography
+    edge_followed_by
+    edge_follow
+    profile_pic_url
+    profile_pic_url_hd
   }
 }
 ```

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -11,6 +11,8 @@ module.exports = {
     `gatsby-transformer-remark`,
     `gatsby-plugin-sharp`,
     {
+      // For development
+      // resolve: `..`,
       resolve: `gatsby-source-instagram`,
       options: {
         username: `oasome.blog`,
@@ -19,16 +21,29 @@ module.exports = {
       },
     },
     {
+      // For development
+      // resolve: `..`,
       resolve: `gatsby-source-instagram`,
       options: {
         username: `instagram`,
       },
     },
     {
+      // For development
+      // resolve: `..`,
       resolve: `gatsby-source-instagram`,
       options: {
         type: `hashtag`,
         hashtag: `snowing`,
+      },
+    },
+    {
+      // For development
+      // resolve: `..`,
+      resolve: `gatsby-source-instagram`,
+      options: {
+        type: `user-profile`,
+        username: `oasome.blog`,
       },
     },
   ],

--- a/example/src/components/Container.js
+++ b/example/src/components/Container.js
@@ -1,6 +1,6 @@
 import React, { useContext } from "react"
 import { Box, Heading, Text, ResponsiveContext } from "grommet"
-import { Instagram } from "."
+import { InstagramPosts } from "."
 
 export const Container = ({ title, text, nodes }) => {
   const size = useContext(ResponsiveContext)
@@ -17,7 +17,7 @@ export const Container = ({ title, text, nodes }) => {
         </Box>
       </Box>
 
-      <Instagram nodes={nodes} />
+      <InstagramPosts nodes={nodes} />
     </Box>
   )
 }

--- a/example/src/components/InstagramPosts.js
+++ b/example/src/components/InstagramPosts.js
@@ -60,7 +60,7 @@ const Node = ({ node }) => (
   </Wrapper>
 )
 
-export const Instagram = ({ nodes }) => {
+export const InstagramPosts = ({ nodes }) => {
   const size = useContext(ResponsiveContext)
   return (
     <Grid

--- a/example/src/components/InstagramProfile.js
+++ b/example/src/components/InstagramProfile.js
@@ -1,0 +1,37 @@
+import React, { useContext } from "react"
+import { Box, Heading, Grid, Text, ResponsiveContext, Image } from "grommet"
+
+export const InstagramProfile = ({ profile }) => {
+  const size = useContext(ResponsiveContext)
+  const extraProps =
+    size !== `small` ? { style: { gridColumnStart: 2 } } : undefined
+  return (
+    <Box {...extraProps}>
+      <Grid
+        areas={[
+          { name: "nav", start: [0, 0], end: [0, 0] },
+          { name: "main", start: [1, 0], end: [2, 0] },
+          { name: "foot", start: [0, 1], end: [2, 1] },
+        ]}
+        columns={["small", "flex", "medium"]}
+        rows={["small", "small"]}
+        gap="small"
+      >
+        <Box gridArea="nav" width="small" height="small">
+          <Image fit="cover" src={profile.profile_pic_url_hd} />
+        </Box>
+        <Box gridArea="main" height="small" style={{ padding: "1rem" }}>
+          <Text>
+            <b>@{profile.username}</b>
+          </Text>
+          <Text>{profile.edge_followed_by.count} followers</Text>
+          <Text>{profile.edge_follow.count} following</Text>
+          <Text>{profile.full_name}</Text>
+        </Box>
+        <Box gridArea="foot" style={{ padding: "1rem" }}>
+          <Text>{profile.biography}</Text>
+        </Box>
+      </Grid>
+    </Box>
+  )
+}

--- a/example/src/components/InstagramProfile.js
+++ b/example/src/components/InstagramProfile.js
@@ -1,37 +1,26 @@
 import React, { useContext } from "react"
-import { Box, Heading, Grid, Text, ResponsiveContext, Image } from "grommet"
+import { Box, Text, ResponsiveContext, Image } from "grommet"
 
 export const InstagramProfile = ({ profile }) => {
   const size = useContext(ResponsiveContext)
   const extraProps =
     size !== `small` ? { style: { gridColumnStart: 2 } } : undefined
   return (
-    <Box {...extraProps}>
-      <Grid
-        areas={[
-          { name: "nav", start: [0, 0], end: [0, 0] },
-          { name: "main", start: [1, 0], end: [2, 0] },
-          { name: "foot", start: [0, 1], end: [2, 1] },
-        ]}
-        columns={["small", "flex", "medium"]}
-        rows={["small", "small"]}
-        gap="small"
-      >
-        <Box gridArea="nav" width="small" height="small">
-          <Image fit="cover" src={profile.profile_pic_url_hd} />
-        </Box>
-        <Box gridArea="main" height="small" style={{ padding: "1rem" }}>
-          <Text>
-            <b>@{profile.username}</b>
-          </Text>
-          <Text>{profile.edge_followed_by.count} followers</Text>
-          <Text>{profile.edge_follow.count} following</Text>
-          <Text>{profile.full_name}</Text>
-        </Box>
-        <Box gridArea="foot" style={{ padding: "1rem" }}>
-          <Text>{profile.biography}</Text>
-        </Box>
-      </Grid>
+    <Box pad="large" {...extraProps}>
+      <Box alignSelf="center" width="small" height="small">
+        <Image fit="cover" src={profile.profile_pic_url_hd} />
+      </Box>
+      <Box alignSelf="center" height="small" pad="small">
+        <Text>
+          <b>@{profile.username}</b>
+        </Text>
+        <Text>{profile.edge_followed_by.count} followers</Text>
+        <Text>{profile.edge_follow.count} following</Text>
+        <Text>{profile.full_name}</Text>
+      </Box>
+      <Box alignSelf="center" width="medium" wrap>
+        <Text>{profile.biography}</Text>
+      </Box>
     </Box>
   )
 }

--- a/example/src/components/Sidebar.js
+++ b/example/src/components/Sidebar.js
@@ -23,6 +23,9 @@ const SidebarContent = () => (
     <InternalLink to="/hashtag">
       <Button hoverIndicator>Hashtag</Button>
     </InternalLink>
+    <InternalLink to="/profile">
+      <Button hoverIndicator>Profile</Button>
+    </InternalLink>
     <Box direction="row">
       <Button
         as="a"

--- a/example/src/components/index.js
+++ b/example/src/components/index.js
@@ -1,4 +1,5 @@
 export * from "./Layout"
 export * from "./Sidebar"
-export * from "./Instagram"
+export * from "./InstagramPosts"
+export * from "./InstagramProfile"
 export * from "./Container"

--- a/example/src/pages/profile.js
+++ b/example/src/pages/profile.js
@@ -1,0 +1,29 @@
+import React from "react"
+import { graphql } from "gatsby"
+import { Layout, InstagramProfile } from "../components"
+
+const ProfilePage = ({ data: { instaUserNode } }) => (
+  <Layout>
+    <InstagramProfile profile={instaUserNode} />
+  </Layout>
+)
+
+export const pageQuery = graphql`
+  query ProfileQuery {
+    instaUserNode {
+      id
+      username
+      full_name
+      biography
+      profile_pic_url_hd
+      edge_followed_by {
+        count
+      }
+      edge_follow {
+        count
+      }
+    }
+  }
+`
+
+export default ProfilePage

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -54,6 +54,30 @@ export async function scrapingInstagramHashtags({ hashtag }) {
     })
 }
 
+export async function scrapingInstagramUser({ username }) {
+  return axios
+    .get(`https://www.instagram.com/${username}/`)
+    .then(response => {
+      const data = parseResponse(response)
+      const { user } = data.ProfilePage[0].graphql
+      const infos = {
+        id: user.id,
+        full_name: user.full_name,
+        biography: user.biography,
+        edge_followed_by: user.edge_followed_by,
+        edge_follow: user.edge_follow,
+        profile_pic_url: user.profile_pic_url,
+        profile_pic_url_hd: user.profile_pic_url_hd,
+        username: user.username,
+      }
+      return infos
+    })
+    .catch(err => {
+      console.warn(`\nCould not fetch instagram user. Error status ${err}`)
+      return null
+    })
+}
+
 export async function apiInstagramPosts({
   access_token,
   instagram_id,

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -41,7 +41,7 @@ exports.downloadMediaFile = async ({
           })
         }
       } catch (e) {
-        console.log("error is", e)
+        console.log(`Could not download file, error is`, e)
       }
     }
   }


### PR DESCRIPTION
So here is the new node for a user's profile.

Instead of passing the profile information with every posts, there is now a different node called _InstaUserNode_.

Here are the available fields :
- id
- username
- full_name
- biography
- edge_followed_by (followers)
- edge_follow (who the user follows)
- profile_pic_url
- profile_pic_url_hd

To use _InstaUserNode_, add this to your gatsby-config.js : 
```
plugins: [
  ...
  {
    resolve: `gatsby-source-instagram`,
    options: {
      type: `user-profile`,
      username: `fake_ig`,
    },
  },
  ...
]
```

Here is an example of a GraphQL query : 
```
{
  instaUserNode {
    id
    username
    full_name
  }
}
```
which gives back : 
```
{
  "data": {
    "instaUserNode": {
      "id": "927369274",
      "username": "fake_ig",
      "full_name": "fake ig account"
    }
  }
}
```