### PR TITLE
fix(instagram): parseResponse

### DIFF
--- a/src/instagram.js
+++ b/src/instagram.js
@@ -4,7 +4,7 @@ const cheerio = require(`cheerio`)
 const parseResponse = response => {
   const $ = cheerio.load(response.data)
   const jsonData = $(`html > body > script`)
-    .get(0)
+    .get(1)
     .children[0].data.replace(/window\._sharedData\s?=\s?{/, `{`)
     .replace(/;$/g, ``)
   return JSON.parse(jsonData).entry_data


### PR DESCRIPTION
Instagram has recently(?) added json-ld metadata which broke response
parsing. This updates `parseResponse` to access the correct node.