### PR TITLE
Fix: move @babel/preset-env to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/oorestisime/gatsby-source-instagram/issues"
   },
   "dependencies": {
-    "@babel/preset-env": "^7.4.5",
     "@babel/runtime": "^7.4.5",
     "axios": "^0.19.0",
     "cheerio": "^1.0.0-rc.3",
@@ -17,6 +16,7 @@
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
     "babel-eslint": "10.0.2",
     "babel-preset-gatsby-package": "^0.2.0",
     "cross-env": "^5.1.4",


### PR DESCRIPTION
Reduces warnings for end users of the package who don't have `@babel/preset-env` installed or mismatching versions.

Happy Hacktoberfest!