### PR TITLE
fix: there is only one page data

### DIFF
--- a/src/instagram.js
+++ b/src/instagram.js
@@ -100,6 +100,8 @@ export async function apiInstagramPosts({
     .then(async response => {
       const results = []
       results.push(...response.data.data)
+      // if maxPosts option specified, then check if there is a next field in the response data and the results' length <= maxPosts
+      // otherwise, fetch as more as it can
       while (
         maxPosts ? (response.data.paging.next && results.length <= maxPosts) : response.data.paging.next
       ) {

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -101,8 +101,7 @@ export async function apiInstagramPosts({
       const results = []
       results.push(...response.data.data)
       while (
-        response.data.paging.next ||
-        (maxPosts && results.length <= maxPosts)
+        maxPosts ? (response.data.paging.next && results.length <= maxPosts) : response.data.paging.next
       ) {
         response = await axios(response.data.paging.next)
         results.push(...response.data.data)


### PR DESCRIPTION
Hi,
   It seems to occur some errors when the instagram only have one page data, there will be no `response.data.paging.next`,  so if I set the `MaxPosts` option, it will make something wrong.

I made a simple fix, can you review it?

Thanks.