### PR TITLE
Fix extracting of likes for post node creation

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -52,7 +52,10 @@ function createPostNode(datum, params) {
       type: `InstaNode`,
     },
     children: [],
-    likes: _.get(datum, `edge_liked_by.count`) || datum.like_count,
+    likes:
+      _.get(datum, `edge_liked_by.count`) ||
+      _.get(datum, `edge_media_preview_like.count`) ||
+      datum.like_count,
     caption:
       _.get(datum, `edge_media_to_caption.edges[0].node.text`) || datum.caption,
     thumbnails: datum.thumbnail_resources,


### PR DESCRIPTION
Hi, I found that with the latest changes, the likes of the posts would not get extracted anymore, because the fieldname is different than expected. I wasn't sure if there is any scenario where the old fieldname `edge_liked_by` is important, so I just extended it with the new one `edge_media_preview_like`.