### PR TITLE
Add hashtags to graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ plugins: [
       instagram_id: "your instagram_business_account id",
       paginate: 100,
       maxPosts: 1000,
+      hashtags: true
     },
   },
 ]
@@ -102,6 +103,27 @@ plugins: [
 Passing the username in this case is optional. If the Graph Api throws any exception and the username is provided then it will use the public scraping method as a fallback.
 
 The `paginate` parameter will influence the limit set for the api call (defaults to 100) and the `maxPosts` enables to limit the maximum number of posts we will store. Defaults to undefined.
+
+The `hashtag` parameter can be set to true which will also grab the hashtags from the first 3 comments by default. If you'd like to change the number of comments to check for hashtags you can pass an object like below. Defaults to false.
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-source-instagram`,
+    options: {
+      username: `username`,
+      access_token: "a valid access token",
+      instagram_id: "your instagram_business_account id",
+      hashtags: {
+        enabled: true,
+        commentDepth: 10
+      }
+    },
+  },
+]
+
+```
 
 ### Hashtag scraping
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ query {
         original
         timestamp
         caption
+        hashtags
         localFile {
           childImageSharp {
             fixed(width: 150, height: 150) {

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -20,6 +20,7 @@ module.exports = {
         instagram_id: `17841408507179516`,
         paginate: 20,
         maxPosts: 30,
+        hashtags: true,
       },
     },
     {

--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -23,6 +23,7 @@ export const pageQuery = graphql`
           likes
           caption
           comments
+          hashtags
           localFile {
             childImageSharp {
               fluid(quality: 70, maxWidth: 600, maxHeight: 600) {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -12,6 +12,7 @@ const {
 const defaultOptions = {
   type: `account`,
   paginate: 100,
+  hashtags: false,
 }
 
 async function getInstagramPosts(options) {
@@ -67,6 +68,7 @@ function createPostNode(datum, params) {
     dimensions: datum.dimensions,
     comments:
       _.get(datum, `edge_media_to_comment.count`) || datum.comments_count,
+    hashtags: datum.hashtags,
   }
 }
 

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -84,7 +84,7 @@ function getHashtags(data) {
         : ``
 
     // combine caption and comment strings, then run match
-    const captionHashtags = (caption + comments).match(hashtagMatch)
+    const captionHashtags = (caption + ` ` + comments).match(hashtagMatch)
 
     const hashtags =
       captionHashtags?.length > 0 ?? false


### PR DESCRIPTION
Allows a user to query by hashtags used in posts. Works only with Graph API. 

This PR solves part of the question raised in  #58 except the user must be credentialed. 

* extracts hashtags from caption
* optionally extracts hashtags from comments
* defaults to false

```javascript
hashtags: true // defaults to false
```

or

```javascript
hashtags: {
  enabled: true, // defaults to false
  commentDepth: 10 // defaults to 3
} 
```